### PR TITLE
Fix lock-icon svg link

### DIFF
--- a/sass/blocks/existing/_boss-header.sass
+++ b/sass/blocks/existing/_boss-header.sass
@@ -169,7 +169,7 @@
     font-size: 1.1em
     line-height: 1.2em
     color: white
-    background: $background-color url(/assets/icon-lock-white.svg) 0.6em center no-repeat
+    background: $background-color url(../icons/icon-lock-white.svg) 0.6em center no-repeat
     background-size: 1.1em
 
     +link-to-button($color: white)


### PR DESCRIPTION
Wrong asset path for lock item was causing a 404 error in production